### PR TITLE
Password reset APIs (OTP based)

### DIFF
--- a/src/api/api.controller.ts
+++ b/src/api/api.controller.ts
@@ -20,6 +20,7 @@ import { FusionauthService } from './fusionauth/fusionauth.service';
 import { OtpService } from './otp/otp.service';
 import { SMSResponse } from './sms/sms.interface';
 import { RefreshRequest } from '@fusionauth/typescript-client/build/src/FusionAuthClient';
+import { ChangePasswordDTO } from '../user/dto/changePassword.dto';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const CryptoJS = require('crypto-js');
 
@@ -262,6 +263,32 @@ export class ApiController {
   ): Promise<UsersResponse> {
     return await this.apiService.activateUserById(
       userId,
+      applicationId,
+      authHeader,
+    );
+  }
+
+  @Post('/changePassword/sendOTP')
+  async changePasswordOTP(
+    @Headers('authorization') authHeader,
+    @Headers('x-application-id') applicationId,
+    @Body() data: any,
+  ): Promise<SignupResponse> {
+    return await this.apiService.changePasswordOTP(
+      data.username,
+      applicationId,
+      authHeader,
+    );
+  }
+
+  @Patch('/changePassword/update')
+  async changePassword(
+    @Headers('authorization') authHeader,
+    @Headers('x-application-id') applicationId,
+    @Body() data: ChangePasswordDTO,
+  ): Promise<SignupResponse> {
+    return await this.apiService.changePassword(
+      data,
       applicationId,
       authHeader,
     );

--- a/src/api/api.service.ts
+++ b/src/api/api.service.ts
@@ -20,6 +20,9 @@ import { OtpService } from './otp/otp.service';
 import { v4 as uuidv4 } from 'uuid';
 import { ConfigResolverService } from './config.resolver.service';
 import { RefreshRequest } from '@fusionauth/typescript-client/build/src/FusionAuthClient';
+import { FAStatus } from '../user/fusionauth/fusionauth.service';
+import { ChangePasswordDTO } from '../user/dto/changePassword.dto';
+import { SMSResponseStatus } from '../user/sms/sms.interface';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const CryptoJS = require('crypto-js');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -214,7 +217,7 @@ export class ApiService {
     applicationId: string,
     authHeader?: string,
   ): Promise<any> {
-    return this.fusionAuthService.upddatePasswordWithLoginId(
+    return this.fusionAuthService.updatePasswordWithLoginId(
       data,
       applicationId,
       authHeader,
@@ -406,6 +409,103 @@ export class ApiService {
     );
     const response: SignupResponse = new SignupResponse().init(uuidv4());
     response.result = userResponse.user;
+    return response;
+  }
+
+  async changePasswordOTP(
+    username: string,
+    applicationId: UUID,
+    authHeader: null | string,
+  ): Promise<SignupResponse> {
+    // Get Phone No from username
+    const {
+      statusFA,
+      userId,
+      user,
+    }: { statusFA: FAStatus; userId: UUID; user: User } =
+      await this.fusionAuthService.getUser(username, applicationId, authHeader);
+    const response: SignupResponse = new SignupResponse().init(uuidv4());
+    // If phone number is valid => Send OTP
+    if (statusFA === FAStatus.USER_EXISTS) {
+      const re = /^[6-9]{1}[0-9]{9}$/;
+      if (re.test(user.mobilePhone)) {
+        const result = await this.otpService.sendOTP(user.mobilePhone);
+        response.result = {
+          data: result,
+          responseMsg: `OTP has been sent to ${user.mobilePhone}.`,
+        };
+        response.responseCode = ResponseCode.OK;
+        response.params.status = ResponseStatus.success;
+      } else {
+        response.responseCode = ResponseCode.FAILURE;
+        response.params.err = 'INVALID_PHONE_NUMBER';
+        response.params.errMsg = 'Invalid Phone number';
+        response.params.status = ResponseStatus.failure;
+      }
+    } else {
+      response.responseCode = ResponseCode.FAILURE;
+      response.params.err = 'INVALID_USERNAME';
+      response.params.errMsg = 'No user with this Username exists';
+      response.params.status = ResponseStatus.failure;
+    }
+    return response;
+  }
+
+  async changePassword(
+    data: ChangePasswordDTO,
+    applicationId: UUID,
+    authHeader: null | string,
+  ): Promise<SignupResponse> {
+    // Verify OTP
+    const {
+      statusFA,
+      userId,
+      user,
+    }: { statusFA: FAStatus; userId: UUID; user: User } =
+      await this.fusionAuthService.getUser(
+        data.username,
+        applicationId,
+        authHeader,
+      );
+    const response: SignupResponse = new SignupResponse().init(uuidv4());
+    if (statusFA === FAStatus.USER_EXISTS) {
+      const verifyOTPResult = await this.otpService.verifyOTP({
+        phone: user.mobilePhone,
+        otp: data.OTP,
+      });
+
+      if (verifyOTPResult.status === SMSResponseStatus.success) {
+        const result = await this.fusionAuthService.updatePassword(
+          userId,
+          data.password,
+          applicationId,
+          authHeader,
+        );
+
+        if (result.statusFA == FAStatus.SUCCESS) {
+          response.result = {
+            responseMsg: 'Password updated successfully',
+          };
+          response.responseCode = ResponseCode.OK;
+          response.params.status = ResponseStatus.success;
+        } else {
+          response.responseCode = ResponseCode.FAILURE;
+          response.params.err = 'UNCAUGHT_EXCEPTION';
+          response.params.errMsg = 'Server Error';
+          response.params.status = ResponseStatus.failure;
+        }
+      } else {
+        response.responseCode = ResponseCode.FAILURE;
+        response.params.err = 'INVALID_OTP_USERNAME_PAIR';
+        response.params.errMsg = 'OTP and Username did not match.';
+        response.params.status = ResponseStatus.failure;
+      }
+    } else {
+      response.responseCode = ResponseCode.FAILURE;
+      response.params.err = 'INVALID_USERNAME';
+      response.params.errMsg = 'No user with this Username exists';
+      response.params.status = ResponseStatus.failure;
+    }
     return response;
   }
 }


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/Samagra-Development/uci-pwa/blob/main/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

APIs added to support password reset for users with phone numbers registered.

### Changes
APIs added:
- POST `/api/changePassword/sendOTP`
- PATCH `/api/changePassword/update`

Fusion Auth service cleanup was done.