### PR TITLE
Fix: Query String Generated by Service returns Error

### DIFF
--- a/src/api/fusionauth/query-generator/query-generator.service.spec.ts
+++ b/src/api/fusionauth/query-generator/query-generator.service.spec.ts
@@ -3,10 +3,10 @@ import { QueryGeneratorService } from './query-generator.service';
 
 describe('QueryGeneratorService', () => {
   let service: QueryGeneratorService;
-  const applicationId = "1234-1234-1234-1234";
-  const applicationIds = ["1234-1234-1234-1234", "1234-1234-1234-1234"];
-  const queryString = "test";
-  
+  const applicationId = '1234-1234-1234-1234';
+  const applicationIds = ['1234-1234-1234-1234', '1234-1234-1234-1234'];
+  const queryString = 'test';
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [QueryGeneratorService],
@@ -25,28 +25,27 @@ describe('QueryGeneratorService', () => {
         must: [
           {
             nested: {
-              path: "registrations",
+              path: 'registrations',
               query: {
                 bool: {
                   must: [
                     {
                       match: {
-                        "registrations.applicationId": applicationId
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          }
-        ]
-      }
-    })
+                        'registrations.applicationId': applicationId,
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
 
     jest.spyOn(service, 'queryUsersByApplicationId');
     expect(service.queryUsersByApplicationId(applicationId)).toBe(result);
-
-  })
+  });
 
   it('should create queryUsersByApplicationIdAndQueryString query', () => {
     const result = JSON.stringify({
@@ -55,32 +54,34 @@ describe('QueryGeneratorService', () => {
           {
             bool: {
               must: [
-                [
-                  {
-                    nested: {
-                      path: "registrations",
-                      query: {
-                        bool: {
-                          should: service.createMatchTags(applicationIds)
-                        }
-                      }
-                    }
-                  }
-                ]
-              ]
-            }
+                {
+                  nested: {
+                    path: 'registrations',
+                    query: {
+                      bool: {
+                        should: service.createMatchTags(applicationIds),
+                      },
+                    },
+                  },
+                },
+              ],
+            },
           },
           {
             query_string: {
-              query: queryString
-            }
-          }
-        ]
-      }
-    })
+              query: queryString,
+            },
+          },
+        ],
+      },
+    });
 
     jest.spyOn(service, 'queryUsersByApplicationIdAndQueryString');
-    expect(service.queryUsersByApplicationIdAndQueryString(applicationIds, queryString)).toBe(result);
-
-  })
+    expect(
+      service.queryUsersByApplicationIdAndQueryString(
+        applicationIds,
+        queryString,
+      ),
+    ).toBe(result);
+  });
 });

--- a/src/api/fusionauth/query-generator/query-generator.service.ts
+++ b/src/api/fusionauth/query-generator/query-generator.service.ts
@@ -2,78 +2,77 @@ import { Injectable } from '@nestjs/common';
 
 @Injectable()
 export class QueryGeneratorService {
-    constructor(){}
+  constructor() {}
 
-    queryUsersByApplicationId(applicationId: string): string{
-        const query = {
+  queryUsersByApplicationId(applicationId: string): string {
+    const query = {
+      bool: {
+        must: [
+          {
+            nested: {
+              path: 'registrations',
+              query: {
+                bool: {
+                  must: [
+                    {
+                      match: {
+                        'registrations.applicationId': applicationId,
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      },
+    };
+    return JSON.stringify(query);
+  }
+
+  queryUsersByApplicationIdAndQueryString(
+    applicationId: string[],
+    queryString: string,
+  ): string {
+    const query = {
+      bool: {
+        must: [
+          {
             bool: {
               must: [
                 {
                   nested: {
-                    path: "registrations",
+                    path: 'registrations',
                     query: {
                       bool: {
-                        must: [
-                          {
-                            match: {
-                              "registrations.applicationId": applicationId
-                            }
-                          }
-                        ]
-                      }
-                    }
-                  }
-                }
-              ]
-            }
-          }
-          return JSON.stringify(query);
-    }
-
-    queryUsersByApplicationIdAndQueryString(applicationId: string[], queryString: string): string{
-        const query = {
-            bool: {
-              must: [
-                {
-                  bool: {
-                    must: [
-                      [
-                        {
-                          nested: {
-                            path: "registrations",
-                            query: {
-                              bool: {
-                                should: this.createMatchTags(applicationId)
-                              }
-                            }
-                          }
-                        }
-                      ]
-                    ]
-                  }
+                        should: this.createMatchTags(applicationId),
+                      },
+                    },
+                  },
                 },
-                {
-                  query_string: {
-                    query: queryString
-                  }
-                }
-              ]
-            }
-          }
-          return JSON.stringify(query)
-    }
+              ],
+            },
+          },
+          {
+            query_string: {
+              query: queryString,
+            },
+          },
+        ],
+      },
+    };
+    return JSON.stringify(query);
+  }
 
-    createMatchTags(arr: string[]): Array<{match: any}>{
-        let tags:  Array<{match: any}> = [];
-        for(let x of arr){
-            tags.push(
-                {
-                    match: {
-                      "registrations.applicationId": x
-                    }
-                }
-            )
-        }
-        return tags;
+  createMatchTags(arr: string[]): Array<{ match: any }> {
+    const tags: Array<{ match: any }> = [];
+    for (const x of arr) {
+      tags.push({
+        match: {
+          'registrations.applicationId': x,
+        },
+      });
     }
+    return tags;
+  }
 }


### PR DESCRIPTION
<!-- Please refer to CONTRIBUTING.md (https://github.com/Samagra-Development/uci-pwa/blob/main/CONTRIBUTING.md)
before creating the pull request to make sure you follow all the standards. -->

## Description

The query returned by the query builder returns the following error:
```
The [query] field is invalid. Explanation [No explanation available].
```

### Changes

For this [query generator](https://github.com/Samagra-Development/user-service/blob/eeaf61ec6ee8f30576b68ee9fce1f238b7ab4c54/src/api/fusionauth/query-generator/query-generator.service.ts#L33):
```ts
queryUsersByApplicationIdAndQueryString(applicationId: string[], queryString: string): string{
        const query = {
            bool: {
              must: [
                {
                  bool: {
                    must: [
                      [
                        {
                          nested: {
                            path: "registrations",
                            query: {
                              bool: {
                                should: this.createMatchTags(applicationId)
                              }
                            }
                          }
                        }
                      ]
                    ]
                  }
                },
                {
                  query_string: {
                    query: queryString
                  }
                }
              ]
            }
          }
          return JSON.stringify(query)
    }  
```
The innermost `must` clause is now Array<Obj> instead of being Array<Array<Obj>>:

```ts
queryUsersByApplicationIdAndQueryString(applicationId: string[], queryString: string): string{
        const query = {
            bool: {
              must: [
                {
                  bool: {
                    must: [
                        {
                          nested: {
                            path: "registrations",
                            query: {
                              bool: {
                                should: this.createMatchTags(applicationId)
                              }
                            }
                          }
                        }
                    ]
                  }
                },
                {
                  query_string: {
                    query: queryString
                  }
                }
              ]
            }
          }
          return JSON.stringify(query)
    }
```

## How to test
- updated src/api/fusionauth/query-generator/query-generator.service.spec.ts to run the relevant test
- The following curl should return success, responseCode: "OK"
```sh
curl --location 'http://localhost:3000/api/searchUserByQuery?queryString=username%3AvalidUsername&startRow=0&numberOfResults=1' \
--header 'x-application-id: ***' \
--header 'Authorization: ***'
```